### PR TITLE
Settings: continue factory reset if user leaves activity

### DIFF
--- a/src/com/android/settings/MasterClearConfirm.java
+++ b/src/com/android/settings/MasterClearConfirm.java
@@ -106,10 +106,22 @@ public class MasterClearConfirm extends DialogFragment {
         public void onResume() {
             super.onResume();
             new AsyncTask<Void, Void, Void>() {
+
+                Context mContext;
+                boolean mWipeMedia;
+                boolean mWipeSdCard;
+
+                @Override
+                protected void onPreExecute() {
+                    mContext = getActivity().getApplicationContext();
+                    mWipeMedia = getArguments().getBoolean(MasterClear.EXTRA_WIPE_MEDIA);
+                    mWipeSdCard = getArguments().getBoolean(MasterClear.EXTRA_WIPE_SDCARD);
+                }
+
                 @Override
                 protected Void doInBackground(Void... params) {
                     final PersistentDataBlockManager pdbManager = (PersistentDataBlockManager)
-                            getActivity().getSystemService(Context.PERSISTENT_DATA_BLOCK_SERVICE);
+                            mContext.getSystemService(Context.PERSISTENT_DATA_BLOCK_SERVICE);
                     if (pdbManager != null) pdbManager.wipe();
                     return null;
                 }
@@ -117,9 +129,7 @@ public class MasterClearConfirm extends DialogFragment {
                 @Override
                 protected void onPostExecute(Void aVoid) {
                     FrpDialog.this.dismissAllowingStateLoss();
-                    doMasterClear(getActivity(),
-                            getArguments().getBoolean(MasterClear.EXTRA_WIPE_MEDIA),
-                            getArguments().getBoolean(MasterClear.EXTRA_WIPE_SDCARD));
+                    doMasterClear(mContext, mWipeMedia, mWipeSdCard);
                 }
             }.execute();
         }


### PR DESCRIPTION
If the FRP dialog is up, and the user presses the home button, the FRP
task will finish, and then try to use the activity context to initiate
the wipe, and the fragment to retreive args, both of which is no longer
valid.

Cache all variables before the task begins, and use the application
context to complete the calls.

Ref: CYNGNOS-427

Change-Id: I5c8b286195a0b57fd879a1022d64ea548363b925
Signed-off-by: Roman Birg roman@cyngn.com
