### PR TITLE
settings: LiveDisplay color profiles

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -1165,6 +1165,18 @@
     <string name="live_display_enhance_color_title">Enhance colors</string>
     <string name="live_display_enhance_color_summary">Improve color vibrance of flesh tones, scenery, and other images</string>
 
+    <string name="live_display_color_profile_title">Color profile</string>
+    <string name="live_display_color_profile_standard_title">Standard</string>
+    <string name="live_display_color_profile_standard_summary">Accurate colors and bright whites</string>
+    <string name="live_display_color_profile_natural_title">Natural</string>
+    <string name="live_display_color_profile_natural_summary">Realistic colors and flesh tones</string>
+    <string name="live_display_color_profile_dynamic_title">Dynamic</string>
+    <string name="live_display_color_profile_dynamic_summary">Enhanced colors and bright whites</string>
+    <string name="live_display_color_profile_cinema_title">Cinema</string>
+    <string name="live_display_color_profile_cinema_summary">Perfect color reproduction for media</string>
+    <string name="live_display_color_profile_astronomy_title">Astronomy</string>
+    <string name="live_display_color_profile_astronomy_summary">Deep red for preserving night vision</string>
+
     <string name="battery_saver_threshold">Battery saver threshold</string>
     <string name="battery_saver_summary">Reduce performance and limit background data</string>
     <string name="battery_saver_summary_unavailable">Not available while charging</string>

--- a/res/xml/livedisplay.xml
+++ b/res/xml/livedisplay.xml
@@ -21,6 +21,12 @@
         android:key="live_display_options"
         android:title="@string/live_display_title">
 
+        <!-- Color profile -->
+        <ListPreference
+                android:key="live_display_color_profile"
+                android:title="@string/live_display_color_profile_title"
+                android:persistent="false" />
+
         <ListPreference
                 android:key="live_display"
                 android:title="@string/live_display_mode"
@@ -40,27 +46,11 @@
                 android:summary="@string/live_display_outdoor_mode_summary"
                 android:defaultValue="true" />
 
-        <!-- Adaptive backlight -->
-        <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
-                android:key="display_low_power"
-                android:title="@string/live_display_low_power_title"
-                android:summary="@string/live_display_low_power_summary"
-                android:defaultValue="true"
-                settings:advanced="true" />
-
-        <!-- Color enhancement -->
-        <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
-                android:key="display_color_enhance"
-                android:title="@string/live_display_enhance_color_title"
-                android:summary="@string/live_display_enhance_color_summary"
-                android:defaultValue="true"
-                settings:advanced="true" />
-
     </PreferenceCategory>
 
     <PreferenceCategory
-            android:key="calibration"
-            android:title="@string/category_calibration"
+            android:key="advanced"
+            android:title="@string/advanced"
             settings:advanced="true">
 
         <!-- screen color -->
@@ -91,6 +81,22 @@
                 android:summary="@string/gamma_tuning_summary_head"
                 android:persistent="false"
                 settings:advanced="true"/>
+
+        <!-- Adaptive backlight -->
+        <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
+                android:key="display_low_power"
+                android:title="@string/live_display_low_power_title"
+                android:summary="@string/live_display_low_power_summary"
+                android:defaultValue="true"
+                settings:advanced="true" />
+
+        <!-- Color enhancement -->
+        <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
+                android:key="display_color_enhance"
+                android:title="@string/live_display_enhance_color_title"
+                android:summary="@string/live_display_enhance_color_summary"
+                android:defaultValue="true"
+                settings:advanced="true" />
 
     </PreferenceCategory>
 

--- a/src/com/android/settings/livedisplay/LiveDisplay.java
+++ b/src/com/android/settings/livedisplay/LiveDisplay.java
@@ -17,6 +17,7 @@ package com.android.settings.livedisplay;
 
 import static cyanogenmod.hardware.CMHardwareManager.FEATURE_ADAPTIVE_BACKLIGHT;
 import static cyanogenmod.hardware.CMHardwareManager.FEATURE_COLOR_ENHANCEMENT;
+import static cyanogenmod.hardware.CMHardwareManager.FEATURE_DISPLAY_MODES;
 import static cyanogenmod.hardware.CMHardwareManager.FEATURE_DISPLAY_GAMMA_CALIBRATION;
 import static cyanogenmod.hardware.CMHardwareManager.FEATURE_SUNLIGHT_ENHANCEMENT;
 
@@ -38,6 +39,7 @@ import android.preference.PreferenceScreen;
 import android.preference.SwitchPreference;
 import android.provider.SearchIndexableResource;
 import android.provider.Settings;
+import android.util.Log;
 
 import com.android.internal.util.ArrayUtils;
 import com.android.settings.R;
@@ -47,6 +49,7 @@ import com.android.settings.search.BaseSearchIndexProvider;
 import com.android.settings.search.Indexable;
 
 import cyanogenmod.hardware.CMHardwareManager;
+import cyanogenmod.hardware.DisplayMode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +60,7 @@ public class LiveDisplay extends SettingsPreferenceFragment implements
     private static final String TAG = "LiveDisplay";
 
     private static final String KEY_CATEGORY_LIVE_DISPLAY = "live_display_options";
-    private static final String KEY_CATEGORY_CALIBRATION = "calibration";
+    private static final String KEY_CATEGORY_ADVANCED = "advanced";
 
     private static final String KEY_LIVE_DISPLAY = "live_display";
     private static final String KEY_LIVE_DISPLAY_AUTO_OUTDOOR_MODE =
@@ -69,6 +72,8 @@ public class LiveDisplay extends SettingsPreferenceFragment implements
     private static final String KEY_DISPLAY_COLOR = "color_calibration";
     private static final String KEY_DISPLAY_GAMMA = "gamma_tuning";
     private static final String KEY_SCREEN_COLOR_SETTINGS = "screencolor_settings";
+
+    private static final String KEY_LIVE_DISPLAY_COLOR_PROFILE = "live_display_color_profile";
 
     public static final int MODE_OFF = 0;
     public static final int MODE_NIGHT = 1;
@@ -88,12 +93,16 @@ public class LiveDisplay extends SettingsPreferenceFragment implements
     private PreferenceScreen mScreenColorSettings;
     private DisplayTemperature mDisplayTemperature;
 
+    private ListPreference mColorProfile;
+
     private String[] mModeEntries;
     private String[] mModeValues;
     private String[] mModeSummaries;
 
     private int mDefaultDayTemperature;
     private int mDefaultNightTemperature;
+
+    private boolean mHasDisplayModes = false;
 
     private CMHardwareManager mHardware;
 
@@ -115,14 +124,14 @@ public class LiveDisplay extends SettingsPreferenceFragment implements
 
         PreferenceCategory liveDisplayPrefs = (PreferenceCategory)
                 findPreference(KEY_CATEGORY_LIVE_DISPLAY);
-        PreferenceCategory calibrationPrefs = (PreferenceCategory)
-                findPreference(KEY_CATEGORY_CALIBRATION);
+        PreferenceCategory advancedPrefs = (PreferenceCategory)
+                findPreference(KEY_CATEGORY_ADVANCED);
 
-        int displayMode = Settings.System.getIntForUser(resolver,
+        int adaptiveMode = Settings.System.getIntForUser(resolver,
                 Settings.System.DISPLAY_TEMPERATURE_MODE,
                 0, UserHandle.USER_CURRENT);
         mLiveDisplay = (ListPreference) findPreference(KEY_LIVE_DISPLAY);
-        mLiveDisplay.setValue(String.valueOf(displayMode));
+        mLiveDisplay.setValue(String.valueOf(adaptiveMode));
 
         mModeEntries = res.getStringArray(
                 com.android.internal.R.array.live_display_entries);
@@ -158,11 +167,13 @@ public class LiveDisplay extends SettingsPreferenceFragment implements
 
         mDisplayTemperature = (DisplayTemperature) findPreference(KEY_LIVE_DISPLAY_TEMPERATURE);
 
-        mLowPower = (SwitchPreference) findPreference(KEY_LIVE_DISPLAY_LOW_POWER);
-        if (liveDisplayPrefs != null && mLowPower != null
-                && !mHardware.isSupported(FEATURE_ADAPTIVE_BACKLIGHT)) {
-            liveDisplayPrefs.removePreference(mLowPower);
-            mLowPower = null;
+        mColorProfile = (ListPreference) findPreference(KEY_LIVE_DISPLAY_COLOR_PROFILE);
+        if (liveDisplayPrefs != null && mColorProfile != null
+                && (!mHardware.isSupported(FEATURE_DISPLAY_MODES) || !updateDisplayModes())) {
+            liveDisplayPrefs.removePreference(mColorProfile);
+        } else {
+            mHasDisplayModes = true;
+            mColorProfile.setOnPreferenceChangeListener(this);
         }
 
         mOutdoorMode = (SwitchPreference) findPreference(KEY_LIVE_DISPLAY_AUTO_OUTDOOR_MODE);
@@ -172,31 +183,33 @@ public class LiveDisplay extends SettingsPreferenceFragment implements
             mOutdoorMode = null;
         }
 
+        mLowPower = (SwitchPreference) findPreference(KEY_LIVE_DISPLAY_LOW_POWER);
+        if (advancedPrefs != null && mLowPower != null
+                && !mHardware.isSupported(FEATURE_ADAPTIVE_BACKLIGHT)) {
+            advancedPrefs.removePreference(mLowPower);
+            mLowPower = null;
+        }
+
         mColorEnhancement = (SwitchPreference) findPreference(KEY_LIVE_DISPLAY_COLOR_ENHANCE);
-        if (liveDisplayPrefs != null && mColorEnhancement != null
+        if (advancedPrefs != null && mColorEnhancement != null
                 && !mHardware.isSupported(FEATURE_COLOR_ENHANCEMENT)) {
-            liveDisplayPrefs.removePreference(mColorEnhancement);
+            advancedPrefs.removePreference(mColorEnhancement);
             mColorEnhancement = null;
         }
 
-        if (calibrationPrefs != null
+        if (advancedPrefs != null
                 && !mHardware.isSupported(FEATURE_DISPLAY_GAMMA_CALIBRATION)) {
             Preference gammaPref = findPreference(KEY_DISPLAY_GAMMA);
             if (gammaPref != null) {
-                calibrationPrefs.removePreference(gammaPref);
+                advancedPrefs.removePreference(gammaPref);
             }
         }
 
         mScreenColorSettings = (PreferenceScreen) findPreference(KEY_SCREEN_COLOR_SETTINGS);
-        if (calibrationPrefs != null) {
-            if (!isPostProcessingSupported(getActivity()) && mScreenColorSettings != null) {
-                calibrationPrefs.removePreference(mScreenColorSettings);
-            } else if ("user".equals(Build.TYPE)) {
-                // Remove simple RGB controls if HSIC controls are available
-                Preference displayColor = findPreference(KEY_DISPLAY_COLOR);
-                if (displayColor != null) {
-                    calibrationPrefs.removePreference(displayColor);
-                }
+        if (advancedPrefs != null) {
+            if (mScreenColorSettings != null &&
+                    (mHasDisplayModes ||!isPostProcessingSupported(getActivity()))) {
+                advancedPrefs.removePreference(mScreenColorSettings);
             }
         }
     }
@@ -206,6 +219,7 @@ public class LiveDisplay extends SettingsPreferenceFragment implements
         super.onResume();
         updateModeSummary();
         updateTemperatureSummary();
+        updateColorProfileSummary(null);
         mObserver.register(true);
     }
 
@@ -215,12 +229,78 @@ public class LiveDisplay extends SettingsPreferenceFragment implements
         mObserver.register(false);
     }
 
+    private boolean updateDisplayModes() {
+        final DisplayMode[] modes = mHardware.getDisplayModes();
+        if (modes == null || modes.length == 0) {
+            return false;
+        }
+
+        final DisplayMode cur = mHardware.getDefaultDisplayMode();
+        int curId = -1;
+        String[] entries = new String[modes.length];
+        String[] values = new String[modes.length];
+        String[] summaries = new String[modes.length];
+        for (int i = 0; i < modes.length; i++) {
+            values[i] = String.valueOf(modes[i].id);
+            entries[i] = modes[i].name;
+            summaries[i] = modes[i].name;
+            if (cur != null && modes[i].id == cur.id) {
+                curId = -1;
+            }
+        }
+        mColorProfile.setEntries(entries);
+        mColorProfile.setEntryValues(values);
+        if (curId >= 0) {
+            mColorProfile.setValue(String.valueOf(curId));
+        }
+
+        return true;
+    }
+
+    private void updateColorProfileSummary(String value) {
+        if (!mHasDisplayModes) {
+            return;
+        }
+
+        if (value == null) {
+            DisplayMode cur = mHardware.getDefaultDisplayMode();
+            if (cur != null && cur.id >= 0) {
+                value = String.valueOf(cur.id);
+            }
+        }
+
+        int idx = mColorProfile.findIndexOfValue(value);
+        if (idx < 0) {
+            Log.e(TAG, "No summary resource found for profile " + value);
+            mColorProfile.setSummary(null);
+            return;
+        }
+
+        mColorProfile.setValue(value);
+
+        String entry = mColorProfile.getEntries()[idx].toString();
+        String name = entry.toLowerCase().replace(" ", "_");
+        String summaryRes = String.format("live_display_color_profile_%s_summary", name);
+        int resId = getResources().getIdentifier(summaryRes, "string", "com.android.settings");
+        if (resId <= 0) {
+            Log.e(TAG, "No summary resource found for profile " + name);
+            mColorProfile.setSummary(null);
+            return;
+        }
+        mColorProfile.setSummary(String.format("%s - %s", entry.toString(),
+                getResources().getString(resId)));
+    }
+
     private void updateModeSummary() {
         int mode = Settings.System.getIntForUser(getContentResolver(),
                 Settings.System.DISPLAY_TEMPERATURE_MODE,
                 MODE_OFF, UserHandle.USER_CURRENT);
 
         int index = ArrayUtils.indexOf(mModeValues, String.valueOf(mode));
+        if (index < 0) {
+            index = ArrayUtils.indexOf(mModeValues, String.valueOf(MODE_OFF));
+        }
+
         mLiveDisplay.setSummary(mModeSummaries[index]);
 
         if (mDisplayTemperature != null) {
@@ -251,6 +331,16 @@ public class LiveDisplay extends SettingsPreferenceFragment implements
             Settings.System.putIntForUser(getContentResolver(),
                     Settings.System.DISPLAY_TEMPERATURE_MODE,
                     Integer.valueOf((String)objValue), UserHandle.USER_CURRENT);
+        } else if (preference == mColorProfile) {
+            int id = Integer.valueOf((String)objValue);
+            Log.i("LiveDisplay", "Setting mode: " + id);
+            for (DisplayMode mode : mHardware.getDisplayModes()) {
+                if (mode.id == id) {
+                    mHardware.setDisplayMode(mode, true);
+                    updateColorProfileSummary((String)objValue);
+                    break;
+                }
+            }
         }
         return true;
     }
@@ -313,6 +403,9 @@ public class LiveDisplay extends SettingsPreferenceFragment implements
              CMHardwareManager hardware = CMHardwareManager.getInstance(context);
 
             ArrayList<String> result = new ArrayList<String>();
+            if (!hardware.isSupported(FEATURE_DISPLAY_MODES)) {
+                result.add(KEY_LIVE_DISPLAY_COLOR_PROFILE);
+            }
             if (!hardware.isSupported(FEATURE_SUNLIGHT_ENHANCEMENT)) {
                 result.add(KEY_LIVE_DISPLAY_AUTO_OUTDOOR_MODE);
             }


### PR DESCRIPTION
- Add support for using the new DisplayMode HAL, which
  configures the display for a preset mode.
- Clean up the settings a bit, and move advanced stuff
  under an advanced category.

Change-Id: If386c93da99346fbee156b057274b60fd064b49d
