### PR TITLE
Settings: Fix RuntimeException in InputMethod Settings

### DIFF
--- a/src/com/android/settings/inputmethod/InputMethodAndLanguageSettings.java
+++ b/src/com/android/settings/inputmethod/InputMethodAndLanguageSettings.java
@@ -290,6 +290,9 @@ public class InputMethodAndLanguageSettings extends SettingsPreferenceFragment
     }
 
     private void updateUserDictionaryPreference(Preference userDictionaryPreference) {
+        if (userDictionaryPreference == null) {
+            return;
+        }
         final Activity activity = getActivity();
         final TreeSet<String> localeSet = UserDictionaryList.getUserDictionaryLocalesSet(activity);
         if (null == localeSet) {


### PR DESCRIPTION
Fixes:
java.lang.RuntimeException: Unable to resume activity
{com.android.settings/com.android.settings.SubSettings}:
java.lang.NullPointerException: Attempt to invoke virtual
method 'void android.preference.Preference.onPrepareForRemoval()'
on a null object reference

OnResume calls the method changed with an already removed preference
-> results in null being passed and therefore NPE occurs

Change-Id: Idfca3a79aaaac71dfc872bb012b5fd1b2c247341
