### PR TITLE
Settings: add opt out stats event

### DIFF
--- a/src/com/android/settings/cmstats/AnonymousStats.java
+++ b/src/com/android/settings/cmstats/AnonymousStats.java
@@ -20,19 +20,26 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 
-import android.util.ArraySet;
+import android.os.UserHandle;
+import android.preference.Preference;
+import android.preference.PreferenceScreen;
+import android.preference.SwitchPreference;
 import com.android.settings.R;
 import com.android.settings.SettingsPreferenceFragment;
-
-import java.util.Set;
+import cyanogenmod.providers.CMSettings;
 
 public class AnonymousStats extends SettingsPreferenceFragment {
+
     private static final String PREF_FILE_NAME = "CMStats";
     /* package */ static final String ANONYMOUS_OPT_IN = "pref_anonymous_opt_in";
     /* package */ static final String ANONYMOUS_LAST_CHECKED = "pref_anonymous_checked_in";
 
-    /* package */ static final String KEY_JOB_QUEUE = "pref_job_queue";
+    /* package */ static final String KEY_LAST_JOB_ID = "last_job_id";
     /* package */ static final int QUEUE_MAX_THRESHOLD = 1000;
+
+    public static final String KEY_STATS = "stats_collection";
+
+    SwitchPreference mStatsSwitch;
 
     public static SharedPreferences getPreferences(Context context) {
         return context.getSharedPreferences(PREF_FILE_NAME, 0);
@@ -42,62 +49,51 @@ public class AnonymousStats extends SettingsPreferenceFragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.anonymous_stats);
+        mStatsSwitch = (SwitchPreference) findPreference(KEY_STATS);
     }
 
-    public static Set<String> getJobQueue(Context context) {
-        return getPreferences(context).getStringSet(KEY_JOB_QUEUE, new ArraySet<String>());
-    }
-
-    public static void clearJobQueue(Context context) {
-        getPreferences(context)
-                .edit()
-                .remove(KEY_JOB_QUEUE)
-                .commit();
-    }
-
-    public static void addJob(Context context, int jobId) {
-        Set<String> jobQueue = getJobQueue(context);
-        jobQueue.add(String.valueOf(jobId));
-
-        getPreferences(context)
-                .edit()
-                .putStringSet(KEY_JOB_QUEUE, jobQueue)
-                .commit();
-    }
-
-    public static void removeJob(Context context, int jobId) {
-        Set<String> jobQueue = getJobQueue(context);
-        jobQueue.remove(String.valueOf(jobId));
-        getPreferences(context)
-                .edit()
-                .remove(KEY_JOB_QUEUE)
-                .commit();
-
-        getPreferences(context)
-                .edit()
-                .putStringSet(KEY_JOB_QUEUE, jobQueue)
-                .commit();
-    }
-
-    /**
-     * @param context context to use to get prefs
-     * @return Returns the next unused int in the job queue, up until {@link #QUEUE_MAX_THRESHOLD}
-     * is reached, then it will return -1
-     */
-    public static int getNextJobId(Context context) {
-        Set<String> currentQueue = getJobQueue(context);
-
-        if (currentQueue == null) {
-            return 1;
-        } else if (currentQueue.size() >= QUEUE_MAX_THRESHOLD) {
-            return -1;
-        } else {
-            int i = 1;
-            while (currentQueue.contains(String.valueOf(i))) {
-                i++;
+    @Override
+    public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen, Preference preference) {
+        if (preference == mStatsSwitch) {
+            boolean checked = mStatsSwitch.isChecked();
+            if (checked) {
+                // clear opt out flags
+                CMSettings.Secure.putIntForUser(getContentResolver(),
+                        CMSettings.Secure.STATS_COLLECTION_REPORTED, 0, UserHandle.USER_OWNER);
             }
-            return i;
-
+            // will initiate opt out sequence if necessary
+            ReportingServiceManager.setAlarm(getActivity());
+            return true;
         }
+        return super.onPreferenceTreeClick(preferenceScreen, preference);
+    }
+
+    public static void updateLastSynced(Context context) {
+        getPreferences(context)
+                .edit()
+                .putLong(ANONYMOUS_LAST_CHECKED,System.currentTimeMillis())
+                .commit();
+    }
+
+    private static int getLastJobId(Context context) {
+        return getPreferences(context).getInt(KEY_LAST_JOB_ID, 0);
+    }
+
+    private static void setLastJobId(Context context, int id) {
+        getPreferences(context)
+                .edit()
+                .putInt(KEY_LAST_JOB_ID, id)
+                .commit();
+    }
+
+    public static int getNextJobId(Context context) {
+        int lastId = getLastJobId(context);
+        if (lastId >= QUEUE_MAX_THRESHOLD) {
+            lastId = 1;
+        } else {
+            lastId += 1;
+        }
+        setLastJobId(context, lastId);
+        return lastId;
     }
 }

--- a/src/com/android/settings/cmstats/StatsUploadJobService.java
+++ b/src/com/android/settings/cmstats/StatsUploadJobService.java
@@ -43,7 +43,7 @@ import java.util.Map;
 public class StatsUploadJobService extends JobService {
 
     private static final String TAG = StatsUploadJobService.class.getSimpleName();
-    private static final boolean DEBUG = false;
+    private static final boolean DEBUG = Log.isLoggable(TAG, Log.DEBUG);
 
     public static final String KEY_JOB_TYPE = "job_type";
     public static final int JOB_TYPE_CYANOGEN = 1;
@@ -56,6 +56,7 @@ public class StatsUploadJobService extends JobService {
     public static final String KEY_CARRIER = "carrier";
     public static final String KEY_CARRIER_ID = "carrierId";
     public static final String KEY_TIMESTAMP = "timeStamp";
+    public static final String KEY_OPT_OUT = "optOut";
 
     private final Map<JobParameters, StatsUploadTask> mCurrentJobs
             = Collections.synchronizedMap(new ArrayMap<JobParameters, StatsUploadTask>());
@@ -107,16 +108,25 @@ public class StatsUploadJobService extends JobService {
             String deviceCarrier = extras.getString(KEY_CARRIER);
             String deviceCarrierId = extras.getString(KEY_CARRIER_ID);
             long timeStamp = extras.getLong(KEY_TIMESTAMP);
+            boolean optOut = extras.getBoolean(KEY_OPT_OUT);
 
             boolean success = false;
+            int jobType = extras.getInt(KEY_JOB_TYPE, -1);
             if (!isCancelled()) {
-                int jobType = extras.getInt(KEY_JOB_TYPE, -1);
-
                 switch (jobType) {
                     case JOB_TYPE_CYANOGEN:
                         try {
-                            success = uploadToCyanogen(deviceId, deviceName, deviceVersion,
-                                    deviceCountry, deviceCarrier, deviceCarrierId, timeStamp);
+                            JSONObject json = new JSONObject();
+                            json.put("optOut", optOut);
+                            json.put("uniqueId", deviceId);
+                            json.put("deviceName", deviceName);
+                            json.put("version", deviceVersion);
+                            json.put("country", deviceCountry);
+                            json.put("carrier", deviceCarrier);
+                            json.put("carrierId", deviceCarrierId);
+                            json.put("timestamp", timeStamp);
+
+                            success = uploadToCyanogen(json);
                         } catch (IOException | JSONException e) {
                             Log.e(TAG, "Could not upload stats checkin to cyanogen server", e);
                             success = false;
@@ -126,7 +136,7 @@ public class StatsUploadJobService extends JobService {
                     case JOB_TYPE_CMORG:
                         try {
                             success = uploadToCM(deviceId, deviceName, deviceVersion, deviceCountry,
-                                    deviceCarrier, deviceCarrierId);
+                                    deviceCarrier, deviceCarrierId, optOut);
                         } catch (IOException e) {
                             Log.e(TAG, "Could not upload stats checkin to commnity server", e);
                             success = false;
@@ -138,7 +148,6 @@ public class StatsUploadJobService extends JobService {
             if (success) {
                 // we hit the server, succeed either which way.
                 mCurrentJobs.remove(mJobParams);
-                AnonymousStats.removeJob(StatsUploadJobService.this, mJobParams.getJobId());
             }
 
             if (DEBUG)
@@ -151,10 +160,12 @@ public class StatsUploadJobService extends JobService {
 
 
     private boolean uploadToCM(String deviceId, String deviceName, String deviceVersion,
-                               String deviceCountry, String deviceCarrier, String deviceCarrierId)
+                               String deviceCountry, String deviceCarrier, String deviceCarrierId,
+                               boolean optOut)
             throws IOException {
 
         final Uri uri = Uri.parse(getString(R.string.stats_cm_url)).buildUpon()
+                .appendQueryParameter("opt_out", optOut ? "1" : "0")
                 .appendQueryParameter("device_hash", deviceId)
                 .appendQueryParameter("device_name", deviceName)
                 .appendQueryParameter("device_version", deviceVersion)
@@ -182,24 +193,13 @@ public class StatsUploadJobService extends JobService {
 
     }
 
-    private boolean uploadToCyanogen(String deviceId, String deviceName, String deviceVersion,
-                                     String deviceCountry, String carrier, String carrierId,
-                                     long timeStamp)
+    private boolean uploadToCyanogen(JSONObject json)
             throws IOException, JSONException {
         String authToken = getAuthToken();
 
         if (authToken.isEmpty()) {
             Log.w(TAG, "no auth token!");
         }
-
-        JSONObject json = new JSONObject();
-        json.put("uniqueId", deviceId);
-        json.put("deviceName", deviceName);
-        json.put("version", deviceVersion);
-        json.put("country", deviceCountry);
-        json.put("carrier", carrier);
-        json.put("carrierId", carrierId);
-        json.put("timestamp", timeStamp);
 
         URL url = new URL(getString(R.string.stats_cyanogen_url));
         HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
@@ -223,9 +223,13 @@ public class StatsUploadJobService extends JobService {
 
             final int responseCode = urlConnection.getResponseCode();
             final boolean success = responseCode == HttpURLConnection.HTTP_OK;
+
+            final String response = getResponse(urlConnection, !success);
+            if (DEBUG)
+                Log.d(TAG, "server responseCode: " + responseCode +", response=" + response);
+
             if (!success) {
-                Log.w(TAG, "failed sending, server returned: " + getResponse(urlConnection,
-                        !success));
+                Log.w(TAG, "failed sending, server returned: " + response);
             }
             return success;
         } finally {


### PR DESCRIPTION
- Get rid of keeping track of queued jobs, job scheduler does this and
  all we really want is a new job id to not interfere with old ones
  (unless we hit the max jobs allowed, then start the count over).
- Persist whether we have reported metrics for the owner user (once per
  device)

Ref: CYNGNOS-1131
Change-Id: Ib5bac2944b5ca4259ea82a357b24708377c1dc4c
